### PR TITLE
Fix dependency installation issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ios-scriptable-types",
-  "version": "0.0.1",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ios-scriptable-types",
-  "version": "1.4",
+  "version": "1.4.0",
   "description": "Type definitions for the iOS app Scriptable",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I had trouble installing the dependencies with `npm install` on version 6.12.1. This turned out to be the fix. Weird.