### PR TITLE
Add ESLint ^7.0.0 as a peer dependency in eslint-config

### DIFF
--- a/eslint-config/package.json
+++ b/eslint-config/package.json
@@ -15,7 +15,7 @@
   "author": "schl3ck",
   "license": "GPL-3.0",
 	"peerDependencies": {
-	  "eslint": "^6.8.0"
+	  "eslint": "^6.8.0 || ^7.0.0"
 	},
   "bugs": {
     "url": "https://github.com/schl3ck/ios-scriptable-types/issues"


### PR DESCRIPTION
According to the ESLint Migrating to v7.0.0 guide, it doesn't look like this will cause any breaking changes. 

https://eslint.org/docs/user-guide/migrating-to-7.0.0

--- 

My motivation for this change stems from the case where ESLint doesn't support [top-level await](https://github.com/tc39/proposal-top-level-await), but Scriptable does. See: https://github.com/eslint/eslint/issues/13832

Example (not inside an async function):

<img width="488" alt="Screen Shot 2021-05-20 at 4 53 21 PM" src="https://user-images.githubusercontent.com/4109551/119054143-c107b580-b98c-11eb-985a-522eb4fee513.png">

As per a maintainers comment (https://github.com/eslint/eslint/issues/13832#issuecomment-724728889), this led me to try [@babel/plugin-syntax-top-level-await](https://babeljs.io/docs/en/babel-plugin-syntax-top-level-await), which depends on [@babel/eslint-parser](https://github.com/babel/babel/tree/main/eslint/babel-eslint-parser), which [depends on `eslint@>=7.5.0`](https://github.com/babel/babel/blob/12190042e6d62d10272a50bdc624e0db327a705a/eslint/babel-eslint-parser/package.json#L30).

I've copied the `eslintrc.json` file from this project into my own projects and I've found no compatibility issues on my own.

**To clarify, I am not suggesting that babel and all these other dependencies be added to this project, but I am suggesting only that ESLint ^7.0.0 be allowed as a peer dependency.**

Thanks for your time.
